### PR TITLE
Fix "Disable Non-Stealth Detection Penalty"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+lib/
+packages/
+IEMod/bin/
+IEMod/obj/
+.idea/
+*.DotSettings.user

--- a/IEMod/Mods/DetectionMods.cs
+++ b/IEMod/Mods/DetectionMods.cs
@@ -10,10 +10,10 @@ namespace IEMod.Mods
     internal class DetectionMods
     {
         [HarmonyPatch(typeof(CharacterStats))]
-        [HarmonyPatch("DetectionRange")]
+        [HarmonyPatch(nameof(CharacterStats.DetectionRange))]
         static class CharacterStats_DetectionRange_Patch
         {
-            static void Postfix(float __result, CharacterStats __instance)
+            static void Postfix(ref float __result, CharacterStats __instance)
             {
                 if (ModMain.Settings.DisableNonStealthDetectionPenalty &&
                     !Stealth.IsInStealthMode(__instance.gameObject))


### PR DESCRIPTION
The setting didn't seem to be working, looks like it was missing a ref keyword.